### PR TITLE
[release-v1.9] Complete release automation

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -19,6 +19,9 @@ git commit -sm ":fire: remove unneeded workflows" .github/
 git fetch openshift main
 git checkout openshift/main -- openshift OWNERS Makefile
 
+tag=${release/release-/}
+yq write --inplace openshift/project.yaml project.tag "knative-$tag"
+
 # Generate our OCP artifacts
 make generate
 git apply openshift/patches/*

--- a/openshift/release/mirror-upstream-branches.sh
+++ b/openshift/release/mirror-upstream-branches.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Usage: openshift/release/mirror-upstream-branches.sh
+# This should be run from the basedir of the repo with no arguments
+
+
+set -ex
+readonly TMPDIR=$(mktemp -d knativeEventingIstioBranchingCheckXXXX -p /tmp/)
+
+git fetch upstream --tags
+git fetch openshift --tags
+
+# We need to seed this with a few releases that, otherwise, would make
+# the processing regex less clear with more anomalies
+cat >> "$TMPDIR"/midstream_branches <<EOF
+0.2
+0.3
+EOF
+
+git branch --list -a "upstream/release-1.*" | cut -f3 -d'/' | cut -f2 -d'-' > "$TMPDIR"/upstream_branches
+git branch --list -a "openshift/release-v1.*" | cut -f3 -d'/' | cut -f2 -d'v' | cut -f1,2 -d'.' >> "$TMPDIR"/midstream_branches
+
+sort -o "$TMPDIR"/midstream_branches "$TMPDIR"/midstream_branches
+sort -o "$TMPDIR"/upstream_branches "$TMPDIR"/upstream_branches
+comm -32 "$TMPDIR"/upstream_branches "$TMPDIR"/midstream_branches > "$TMPDIR"/new_branches
+
+UPSTREAM_BRANCH=$(cat "$TMPDIR"/new_branches)
+if [ -z "$UPSTREAM_BRANCH" ]; then
+    echo "no new branch, exiting"
+    exit 0
+fi
+echo "found upstream branch: $UPSTREAM_BRANCH"
+readonly UPSTREAM_TAG="knative-v$UPSTREAM_BRANCH.0"
+readonly MIDSTREAM_BRANCH="release-v$UPSTREAM_BRANCH"
+openshift/release/create-release-branch.sh "$UPSTREAM_TAG" "$MIDSTREAM_BRANCH"
+# we would check the error code, but we 'set -e', so assume we're fine
+git push openshift "$MIDSTREAM_BRANCH"

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -9,6 +9,9 @@ REPO_OWNER_NAME="openshift-knative"
 REPO_BRANCH="release-next"
 REPO_BRANCH_CI="${REPO_BRANCH}-ci"
 
+# Check if there's an upstream release we need to mirror downstream
+openshift/release/mirror-upstream-branches.sh
+
 # Reset REPO_BRANCH to upstream/main.
 git fetch upstream main
 git checkout upstream/main -B ${REPO_BRANCH}


### PR DESCRIPTION
- Add mirror upstream branch script based on [1]
- Set tag in project.yaml based on the branch name, similar to [2]

[1] https://github.com/openshift-knative/eventing/blob/main/openshift/release/mirror-upstream-branches.sh
[2] https://github.com/openshift-knative/eventing/blob/0eceb13d49469e774e47f6238c1203d7ae2d8df9/openshift/release/create-release-branch.sh#L21-L22