### PR TITLE
Fail generate.sh script, if subcommand/-script fails

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
 
 release=$(yq r openshift/project.yaml project.tag)


### PR DESCRIPTION
As per title.
Should help to detect errors like described in #12 earlier.