### PR TITLE
Install Cert-Manager

### DIFF
--- a/openshift/install.sh
+++ b/openshift/install.sh
@@ -9,7 +9,7 @@ function install_eventing_with_mesh() {
     export ON_CLUSTER_BUILDS=true
     export DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-marketplace
 
-    make OPENSHIFT_CI="true" SCALE_UP=5 TRACING_BACKEND=zipkin images install-strimzi install-kafka-with-mesh || return $?
+    make OPENSHIFT_CI="true" SCALE_UP=5 TRACING_BACKEND=zipkin images install-certmanager install-strimzi install-kafka-with-mesh || return $?
 
     popd || return $?
 }


### PR DESCRIPTION
Some of the eventing core e2e tests require cert manager, when they setup their environment, even they are skipped: e.g.
https://github.com/knative/eventing/blob/6911db0b3592c6f043455b9be9d3052218cbe05b/test/rekt/container_source_test.go#L99

Otherwise they fail with: 
```
FATAL	environment/magic.go:241	failed to install CA certificates and issuer: the server could not find the requested resource	{"test": "TestContainerSourceWithTLS"}
```

This PR installs cert manager for the e2e tests.