### PR TITLE
[release-v1.11] Force kafka broker class for ApiServerSource tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -68,7 +68,7 @@ function run_eventing_core_tests() {
      --environment.namespace="serverless-tests" \
     --istio.enabled=true || return $?
 
-  go_test_e2e \
+  BROKER_TEMPLATES="${KAFKA_BROKER_TEMPLATES}" go_test_e2e \
     -timeout=1h \
     -parallel=12 \
     -run TestApiServerSource \


### PR DESCRIPTION
is SO we force `Kafka` broker class

https://github.com/openshift-knative/serverless-operator/blob/b60d84aaf8b095102b86bd45381c364bbdf581d1/hack/lib/vars.bash#L36

but that's not enough since the configuration should match the expected one for Kafka brokers