### PR TITLE
Add submodule patch to skip `TestPingSourceWithSecondsInSchedule` test

### DIFF
--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -7,4 +7,10 @@ export GOPATH=/tmp/go
 export GOCACHE=/tmp/go-cache
 export ARTIFACTS=${ARTIFACT_DIR:-$(mktemp -u -t -d)}
 
+pushd "${repo_root_dir}/third_party/eventing"
+echo "Apply eventing submodule patches"
+git apply -v ../../openshift/submodule-patches/eventing/*
+popd
+
+
 "${repo_root_dir}/test/e2e-tests.sh"

--- a/openshift/submodule-patches/eventing/skip-pingsource-seconds-schedule.patch
+++ b/openshift/submodule-patches/eventing/skip-pingsource-seconds-schedule.patch
@@ -1,0 +1,12 @@
+diff --git a/test/rekt/pingsource_test.go b/test/rekt/pingsource_test.go
+index 67210479f..285ff9f97 100644
+--- a/test/rekt/pingsource_test.go
++++ b/test/rekt/pingsource_test.go
+@@ -91,6 +91,7 @@ func TestPingSourceWithCloudEventData(t *testing.T) {
+ }
+ 
+ func TestPingSourceWithSecondsInSchedule(t *testing.T) {
++	t.Skip("Skip, while SO deploys a eventing release, which does not support PingSource with seconds in schedule")
+ 	t.Parallel()
+ 
+ 	ctx, env := global.Environment(


### PR DESCRIPTION
Currently [eventing-istio CI fails](https://github.com/openshift-knative/eventing-istio/pull/120), because we run the e2e tests from main, while we install a previous version of eventing (1.11 via SO), which does not contain this feature.

This PR adds a patch to skip the relevant patch (similar to #18).
This can be reverted after eventing 1.13 gets deployed for the release next tests via SO