### PR TITLE
[release-1.13] Update build image to use new k8s pkg repo

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -5,11 +5,10 @@ FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-open
 
 RUN echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
     echo "name=Kubernetes" >> /etc/yum.repos.d/kubernetes.repo && \
-    echo "baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64" >> /etc/yum.repos.d/kubernetes.repo && \
+    echo "baseurl=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/" >> /etc/yum.repos.d/kubernetes.repo && \
     echo "enabled=1" >> /etc/yum.repos.d/kubernetes.repo && \
     echo "gpgcheck=1" >> /etc/yum.repos.d/kubernetes.repo && \
-    echo "repo_gpgcheck=0" >> /etc/yum.repos.d/kubernetes.repo && \
-    echo "gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" >> /etc/yum.repos.d/kubernetes.repo
+    echo "gpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key" >> /etc/yum.repos.d/kubernetes.repo
 
 RUN yum install -y kubectl httpd-tools
 


### PR DESCRIPTION
Old google repos are removed. See discussion [here](https://redhat-internal.slack.com/archives/CD87JDUB0/p1709542708643019).

Note: This needs to be merged first so it can be tested.

From https://github.com/openshift-knative/hack/pull/128