### PR TITLE
Set submodules URL and branch to midstream fork and given release

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -22,6 +22,13 @@ git checkout openshift/main -- openshift OWNERS OWNERS_ALIASES Makefile
 tag=${target/release-/}
 yq write --inplace openshift/project.yaml project.tag "knative-$tag"
 
+# Update submodules to point to midstream repos with correct branch
+git submodule set-branch --branch "$target" -- "third_party/eventing"
+git submodule set-url -- "third_party/eventing" https://github.com/openshift-knative/eventing.git
+
+git submodule set-branch --branch "$target" -- "third_party/eventing-kafka-broker"
+git submodule set-url -- "third_party/eventing-kafka-broker" https://github.com/openshift-knative/eventing-kafka-broker.git
+
 # Generate our OCP artifacts
 make generate
 git apply openshift/patches/*


### PR DESCRIPTION
Currently we don't set the branchname (and point to the midstream repos) in the submodules config. This leads to PRs like  [here](https://github.com/openshift-knative/eventing-istio/pull/285/commits/f7ed017caf2a4b1c06165390fe2ac82918d7b5c0) where mintmaker tries to update the EBK submodule for eventing-istio 1.15 to a commit from EKB on main (https://github.com/knative-extensions/eventing-kafka-broker/commit/ec9b65b).

This PR addresses it and set the submodules, when the release branch is created:
* submodule URL to point to the corresponding midstream branches
* submodule branch to the release branch name (as eventing, EKB and eventing-istios release branches are aligned this should be fine)