### PR TITLE
Run hack generate tool directly

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -31,16 +31,7 @@ function resolve_resources(){
 
 "${repo_root_dir}/hack/update-deps.sh"
 
-tmp_dir=$(mktemp -d)
-git clone --branch main https://github.com/openshift-knative/hack "$tmp_dir"
-
-pushd "$tmp_dir"
-go install github.com/openshift-knative/hack/cmd/generate
-popd
-
-rm -rf "$tmp_dir"
-
-$(go env GOPATH)/bin/generate \
+GOFLAGS='' go run github.com/openshift-knative/hack/cmd/generate@latest \
   --root-dir "${repo_root_dir}" \
   --generators dockerfile \
   --excludes "vendor.*" \

--- a/openshift/install.sh
+++ b/openshift/install.sh
@@ -7,7 +7,7 @@ function install_eventing_with_mesh() {
     KNATIVE_EVENTING_ISTIO_MANIFESTS_DIR="${SCRIPT_DIR}/release/artifacts"
     export KNATIVE_EVENTING_ISTIO_MANIFESTS_DIR
 
-    go install github.com/openshift-knative/hack/cmd/sobranch@latest
+    GOFLAGS='' go install github.com/openshift-knative/hack/cmd/sobranch@latest
 
     local release
     release=$(yq r "${SCRIPT_DIR}/project.yaml" project.tag)


### PR DESCRIPTION
Fixing current issues with installing hack tools

```
Cloning into '/tmp/hack'...
+ cd /tmp/hack
+ go install github.com/openshift-knative/hack/cmd/generate
go: inconsistent vendoring in /tmp/hack:
...
```