### PR TITLE
[DNM] Test: Scale up to 6 nodes for istio e2e tests

### DIFF
--- a/openshift/install.sh
+++ b/openshift/install.sh
@@ -25,7 +25,7 @@ function install_eventing_with_mesh() {
     export ON_CLUSTER_BUILDS=true
     export DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-marketplace
 
-    make OPENSHIFT_CI="true" SCALE_UP=5 TRACING_BACKEND=zipkin generated-files images install-certmanager install-strimzi install-kafka-with-mesh || return $?
+    make OPENSHIFT_CI="true" SCALE_UP=6 TRACING_BACKEND=zipkin generated-files images install-certmanager install-strimzi install-kafka-with-mesh || return $?
 
     popd || return $?
 }


### PR DESCRIPTION
It seems in current update-to-head jobs, some readyness-check pods are not getting up in time and thus test tests failing. Testing is more workers help on it