### PR TITLE
[release-v1.17] Use 4.19 go builder image

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -3,7 +3,7 @@
 FROM registry.ci.openshift.org/ocp/4.17:cli-artifacts as tools
 
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.19 as builder
 
 ARG TARGETARCH
 

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for cmd/controller.
-ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.19
 ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder

--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -37,7 +37,8 @@ GOFLAGS='' go run github.com/openshift-knative/hack/cmd/generate@latest \
   --excludes "vendor.*" \
   --excludes "third_party.*" \
   --images-from eventing \
-  --images-from eventing-kafka-broker
+  --images-from eventing-kafka-broker \
+  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.19"
 
 "$repo_root_dir/hack/update-codegen.sh"
 


### PR DESCRIPTION
Prow builds are failing, because it can't download the httpd-tools in the builder image (which is based on the rhel-8-release-golang-1.22-openshift-4.17 image). See [here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_eventing-istio/471/pull-ci-openshift-knative-eventing-istio-release-v1.17-419-images/1955528495270465536) for example.
4.17 is EoL for [general support](https://access.redhat.com/support/policy/updates/openshift). Using the 4.19 image seems to fix it.