### PR TITLE
[release-v1.17] Update to Golang 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/eventing-istio
 
-go 1.22.7
+go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -3,7 +3,7 @@
 FROM registry.ci.openshift.org/ocp/4.17:cli-artifacts as tools
 
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19 as builder
 
 ARG TARGETARCH
 

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for cmd/controller.
-ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19
 ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder


### PR DESCRIPTION
Updating to Golang 1.23 due to
```
go: knative.dev/toolbox/modscope@latest: knative.dev/toolbox@v0.0.0-20250612145048-e9fe9e820228 requires go >= 1.23.0 (running go 1.22.9; GOTOOLCHAIN=local)
```
e.g. [here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_eventing-istio/471/pull-ci-openshift-knative-eventing-istio-release-v1.17-419-e2e-tests/1956327140219686912)