### PR TITLE
[release-v1.16] update rpms scan image

### DIFF
--- a/.tekton/docker-build.yaml
+++ b/.tekton/docker-build.yaml
@@ -534,7 +534,7 @@ spec:
       - name: name
         value: rpms-signature-scan
       - name: bundle
-        value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:232bd319a7b85720c645783dcada0b633398424700de3f75549eaf524144007e
+        value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:49ff6d117c3e9dc3966d1244e118e168b3501742ec14c3a4161a276ff48d04d5
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
fix for Error
`Pipeline ocp-serverless-tenant/kn-eventing-webhook-116-on-push-wjsj6 can't be Run; it contains Tasks that don't exist: Couldn't retrieve Task "resolver type bundles\nname = rpms-signature-scan\n": error requesting remote resource: error getting "bundleresolver" "ocp-serverless-tenant/bundles-fa1882011de79a52571365675a6f4f55": cannot retrieve the oci image: GET https://quay.io/v2/konflux-ci/konflux-vanguard/task-rpms-signature-scan/manifests/sha256:232bd319a7b85720c645783dcada0b633398424700de3f75549eaf524144007e: MANIFEST_UNKNOWN: manifest unknown; map[]`