### PR TITLE
[release-v1.17] SO main move on-cluster builds namespace

### DIFF
--- a/openshift/install.sh
+++ b/openshift/install.sh
@@ -23,7 +23,7 @@ function install_eventing_with_mesh() {
     pushd $operator_dir || return $?
 
     export ON_CLUSTER_BUILDS=true
-    export DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-marketplace
+    export DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-serverless-builds
 
     make OPENSHIFT_CI="true" SCALE_UP=5 TRACING_BACKEND=zipkin generated-files images install-certmanager install-strimzi install-kafka-with-mesh || return $?
 


### PR DESCRIPTION
Since https://github.com/openshift-knative/serverless-operator/commit/083f319e5303ea3d4f0e0ab95eaa39795fc6b8cb we use openshift-serverless-builds namespace for on-cluster builds in SO